### PR TITLE
Fix failure to round-trip when data has a __serializedType__ key.

### DIFF
--- a/immutable/serialize.js
+++ b/immutable/serialize.js
@@ -16,6 +16,15 @@ module.exports = function serialize(Immutable, refs, customReplacer, customReviv
     if (Immutable.Set.isSet(value)) return mark(value, 'ImmutableSet', 'toArray');
     if (Immutable.Seq.isSeq(value)) return mark(value, 'ImmutableSeq', 'toArray');
     if (Immutable.Stack.isStack(value)) return mark(value, 'ImmutableStack', 'toArray');
+    if (typeof value === 'object' && value !== null && '__serializedType__' in value) {
+      var copy = Object.assign({}, value);
+      delete copy.__serializedType__;
+      return {
+        __serializedType__: 'Object',
+        data: copy,
+        __serializedType__value: value.__serializedType__,
+      }
+    }
     return value;
   }
 
@@ -36,6 +45,10 @@ module.exports = function serialize(Immutable, refs, customReplacer, customReviv
           return refs && refs[value.__serializedRef__]
             ? new refs[value.__serializedRef__](data)
             : Immutable.Map(data);
+        case 'Object':
+          return Object.assign({}, data, {
+            __serializedType__: value.__serializedType__value,
+          });
         default: return data;
       }
     }

--- a/test/__snapshots__/immutable.spec.js.snap
+++ b/test/__snapshots__/immutable.spec.js.snap
@@ -19,3 +19,5 @@ exports[`Immutable Stringify seq 1`] = `"{\"data\":[1,2,3,4,5,6,7,8],\"__seriali
 exports[`Immutable Stringify set 1`] = `"{\"data\":[1,2,3,4,5,6,7,8,9,10],\"__serializedType__\":\"ImmutableSet\"}"`;
 
 exports[`Immutable Stringify stack 1`] = `"{\"data\":[\"a\",\"b\",\"c\"],\"__serializedType__\":\"ImmutableStack\"}"`;
+
+exports[`Immutable Stringify withTypeKey 1`] = `"{\"__serializedType__\":\"Object\",\"data\":{\"a\":1},\"__serializedType__value\":{\"__serializedType__\":\"Object\",\"data\":{\"b\":[2]},\"__serializedType__value\":{\"c\":[3]}}}"`;

--- a/test/immutable.spec.js
+++ b/test/immutable.spec.js
@@ -13,7 +13,14 @@ var data = {
   set: Immutable.Set([10,9,8,7,6,5,4,3,2,1]),
   orderedSet: Immutable.OrderedSet([10,9,8,7,6,5,4,3,2,1]),
   seq: Immutable.Seq.of(1,2,3,4,5,6,7,8),
-  stack: Immutable.Stack.of('a', 'b', 'c')
+  stack: Immutable.Stack.of('a', 'b', 'c'),
+  withTypeKey: {
+    a: 1,
+    __serializedType__: {
+      b: [2],
+      __serializedType__: {c: [3]},
+    },
+  }
 };
 
 describe('Immutable', function () {


### PR DESCRIPTION
For use in https://github.com/zulip/zulip-mobile/pull/4047 .

